### PR TITLE
rotate polygons in place

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -65,6 +65,7 @@ window.addEventListener("load", function () {
     shapes[6].polygon("0," + size + " " + quart + "," + q3 + " " + q3 + "," + q3 + " " + half + "," + size).fill("#34495e");
 
     Crossy("polygon", "transformOrigin", "center");
+    Crossy("polygon", "transformBox", "fill-box");
     Crossy("polygon", "transition", "all 500 ease");
 
     shapes.forEach(function (c) {


### PR DESCRIPTION
Hi,

This change fixes #11 .

It leverages the CSS property [`transform-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-box), which seems to be made for this exact use-case, ie. specifying what the transform-origin properties should be relative to. In our case, `fill-box` seems like the correct value: "The object bounding box is used as the reference box."

Tested manually in FF and Chrome latest.

cheers,
ditam